### PR TITLE
Chores post queue

### DIFF
--- a/client/actions/postQueueActions.js
+++ b/client/actions/postQueueActions.js
@@ -30,9 +30,32 @@ export const requestQueue = () => {
     })
       .then(response => response.json())
       .then(json => {
-        console.log('/getUser-----------(*DS&F', json.queue);
         dispatch(insertQueue(json));
       })
       .catch(err => console.log(err, '/getUser'));
+  };
+};
+
+export const requestRemove = ({ postId, isActive, index }) => {
+  return dispatch => {
+    fetch(`http://127.0.0.1:3000/post/toggleIsActive`, {
+      method: 'POST',
+      body: JSON.stringify({
+        postId,
+        isActive,
+      }),
+      headers: new Headers({
+        'Content-Type': 'application/json',
+      }),
+    })
+      .then(res => res.json())
+      .then(confirmationOfRemoval => {
+        if (isActive === 'f') {
+          dispatch(removeItem(index));
+        } else {
+          dispatch(insertItem(index));
+        }
+      })
+      .catch(err => console.log('could not remove item', err));
   };
 };

--- a/client/actions/postQueueActions.js
+++ b/client/actions/postQueueActions.js
@@ -37,8 +37,10 @@ export const requestQueue = () => {
 };
 
 export const requestRemove = ({ postId, isActive, index }) => {
+  let token = window.localStorage.getItem('ImPostr-JWT');
   return dispatch => {
-    fetch(`http://127.0.0.1:3000/post/toggleIsActive`, {
+    console.log(JSON.stringify({postId, isActive}));
+    fetch(`http://localhost:3000/post/toggleIsActive`, {
       method: 'POST',
       body: JSON.stringify({
         postId,
@@ -46,6 +48,7 @@ export const requestRemove = ({ postId, isActive, index }) => {
       }),
       headers: new Headers({
         'Content-Type': 'application/json',
+        Authorization: `JWT ${token}`,
       }),
     })
       .then(res => res.json())

--- a/client/components/PostQueue.js
+++ b/client/components/PostQueue.js
@@ -6,6 +6,7 @@ import PostQueueEntry from './PostQueueEntry';
 import PostQueueRemovedEntry from './PostQueueRemovedEntry';
 
 const PostQueue = ({
+  postId,
   queuedItems,
   removedItems,
   onRemoveItemClick,

--- a/client/components/PostQueueEntry.js
+++ b/client/components/PostQueueEntry.js
@@ -7,7 +7,7 @@ const PostQueueEntry = ({ post, onRemoveItemClick, index }) => (
     {`${post.message} will be posted on ${post.platform} at ${moment(post.time).fromNow()}`}
     <Button
       onClick={() => {
-        onRemoveItemClick(index);
+        onRemoveItemClick(post.postId, index);
         console.log(post.postId);
        }}
       bsStyle="warning"

--- a/client/components/PostQueueEntry.js
+++ b/client/components/PostQueueEntry.js
@@ -6,7 +6,10 @@ const PostQueueEntry = ({ post, onRemoveItemClick, index }) => (
   <ListGroupItem>
     {`${post.message} will be posted on ${post.platform} at ${moment(post.time).fromNow()}`}
     <Button
-      onClick={() => { onRemoveItemClick(index); }}
+      onClick={() => {
+        onRemoveItemClick(index);
+        console.log(post.postId);
+       }}
       bsStyle="warning"
       size="small"
     >

--- a/client/components/PostQueueRemovedEntry.js
+++ b/client/components/PostQueueRemovedEntry.js
@@ -7,7 +7,11 @@ const PostQueueRemovedEntry = ({ post, onInsertItemClick, index }) => (
   <ListGroupItem>
     {`${post.message} will NOT be posted anymore on ${post.platform} at ${moment(post.time).fromNow()}`}
     <Button
-      onClick={() => { onInsertItemClick(index); }}
+      onClick={() => {
+        onInsertItemClick(post.postId, index);
+        console.log(post.postId);
+      }}
+
       bsStyle="primary"
       size="small"
     >

--- a/client/containers/PostQueueContainer.js
+++ b/client/containers/PostQueueContainer.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import PostQueue from '../components/PostQueue';
-import { removeItem, insertItem, insertQueue } from '../actions/postQueueActions';
+import { removeItem, insertItem, insertQueue, requestRemove } from '../actions/postQueueActions';
 
 const mapStateToProps = (state) => ({
   queuedItems: state.postQueue.queuedItems,
@@ -8,8 +8,21 @@ const mapStateToProps = (state) => ({
 });
 
 const mapDispatchToProps = (dispatch) => ({
-  onInsertItemClick: (id) => dispatch(insertItem(id)),
-  onRemoveItemClick: (id) => dispatch(removeItem(id)),
+  onInsertItemClick: (postId, index) => {
+    dispatch(requestRemove({
+      postId,
+      isActive: 't',
+      index,
+    }));
+  },
+
+  onRemoveItemClick: (postId, index) => {
+    dispatch(requestRemove({
+      postId,
+      isActive: 'f',
+      index,
+    }));
+  },
 });
 
 const PostQueueContainer = connect(

--- a/client/reducers/postQueue.js
+++ b/client/reducers/postQueue.js
@@ -1,18 +1,7 @@
 import { REMOVE_ITEM_FROM_QUEUE, INSERT_ITEM_FROM_QUEUE, INSERT_QUEUE } from '../actions/postQueueActions';
 
 const PostQueue = (state = {
-  queuedItems: [
-    {
-      message: 'yo',
-      time: 'tomorrow',
-      platform: 'facebook',
-    },
-    {
-      message: 'heyasdfasdf',
-      time: 'tomorrow',
-      platform: 'twitter',
-    },
-  ],
+  queuedItems: [],
   removedItems: [],
 }, action) => {
   switch (action.type) {

--- a/server/posts/post.controller.js
+++ b/server/posts/post.controller.js
@@ -53,11 +53,11 @@ const addNew = (post, cb) => {
 };
 
 //toggleIsActive
-  //for client to update based on user input
+//for client to update based on user input
 const toggleIsActive = (req, res) => {
-  const { postId, isActive } = req.body;
+  const { postId } = req.body;
   Post.update({
-    isActive,
+    isActive: 'f',
   }, {
     where: {
       postId,
@@ -68,11 +68,9 @@ const toggleIsActive = (req, res) => {
   });
 };
 
-
 //getUser
   //for client to get all unserviced posts when user logs in
 const getUser = (req, res) => {
-  console.log('WE HIT GET USER');
   let { userId } = req.user;
   Post.findAll({
     where: {
@@ -80,8 +78,10 @@ const getUser = (req, res) => {
     },
   }).then(userPosts => {
     let justPosts = userPosts.map((obj) => {
-      let { message, expires, platform } = obj.dataValues;
+      let { postId, message, expires, platform } = obj.dataValues;
+      console.log(obj.dataValues);
       return {
+        postId,
         message,
         platform,
         time: expires,

--- a/server/posts/post.controller.js
+++ b/server/posts/post.controller.js
@@ -55,7 +55,9 @@ const addNew = (post, cb) => {
 //toggleIsActive
 //for client to update based on user input
 const toggleIsActive = (req, res) => {
+  console.log(req.body);
   const { postId, isActive } = req.body;
+  console.log(isActive, postId);
   Post.update({
     isActive,
   }, {
@@ -78,16 +80,16 @@ const getUser = (req, res) => {
     },
   }).then(userPosts => {
     let justPosts = userPosts.map((obj) => {
-      let { postId, message, expires, platform } = obj.dataValues;
-      console.log(obj.dataValues);
-      return {
-        postId,
-        message,
-        platform,
-        time: expires,
-      };
+      let { postId, message, expires, platform, isActive } = obj.dataValues;
+      if (isActive === 't') {
+        return {
+          postId,
+          message,
+          platform,
+          time: expires,
+        };
+      }
     });
-    console.log(justPosts);
     res.json({
       queue: justPosts,
     });

--- a/server/posts/post.controller.js
+++ b/server/posts/post.controller.js
@@ -55,9 +55,9 @@ const addNew = (post, cb) => {
 //toggleIsActive
 //for client to update based on user input
 const toggleIsActive = (req, res) => {
-  const { postId } = req.body;
+  const { postId, isActive } = req.body;
   Post.update({
-    isActive: 'f',
+    isActive,
   }, {
     where: {
       postId,

--- a/server/posts/post.routes.js
+++ b/server/posts/post.routes.js
@@ -2,7 +2,7 @@ const PostRouter = require('express').Router();
 const PostCtrl = require('./post.controller');
 
 PostRouter.post('/toggleIsActive', (req, res) => {
-  console.log('/post/toggleIsActive');
+  console.log(req.body, '/post/toggleIsActive');
   PostCtrl.toggleIsActive(req, res);
 });
 

--- a/server/posts/post.routes.js
+++ b/server/posts/post.routes.js
@@ -1,9 +1,8 @@
 const PostRouter = require('express').Router();
 const PostCtrl = require('./post.controller');
 
-PostRouter.put('/toggleIsActive', (req, res) => {
-  console.log(req.body);
-  console.log('/posts/toggleIsActive');
+PostRouter.post('/toggleIsActive', (req, res) => {
+  console.log('/post/toggleIsActive');
   PostCtrl.toggleIsActive(req, res);
 });
 


### PR DESCRIPTION
Client can now correctly remove posts from their global queue.
Previously, it was only removed visually (sorry).
There's still a "removed item" queue and I also implemented a way to re-append items to the queue (only those recently removed).  However, these items do not persist past refresh.  Thus, it'll allow a user to revert a recent change, but not all change history.
